### PR TITLE
make-base-vm: switch apt cacher option, using cacher enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ Also, I had to modify the default /etc/sudoers file to uncomment the `secure_pat
 
 ### Ubuntu:
 
+By default and for regular build, `apt-cacher` server is used to cache dependencies. Install following packages to enable it, otherwise use `--disable-apt-cacher` :
+
+    sudo apt-get install apache2 apt-cacher-ng
+
 This pulls in all pre-requisites for KVM building on Ubuntu:
 
-    sudo apt-get install git apache2 apt-cacher-ng python-vm-builder ruby qemu-utils
+    sudo apt-get install git python-vm-builder ruby qemu-utils
 
 If you'd like to use LXC mode instead, install it as follows:
 
@@ -67,7 +71,7 @@ On Debian Wheezy you run the same command, but you must first add backports to y
 
     sudo port install ruby coreutils
     export PATH=$PATH:/opt/local/libexec/gnubin  # Needed for sha256sum
-    
+
 ### OSX with Homebrew:
 
     brew install ruby coreutils

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -201,7 +201,7 @@ if [ $DOCKER = "1" ]; then
 
   apt_cacher=""
   if [ "$APT_CACHER" = 1 ]; then
-    apt_cacher="RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher"
+    apt_cacher="RUN echo 'Acquire::http { Proxy \"$MIRROR_BASE\"; };' > /etc/apt/apt.conf.d/50cacher"
   fi
 
   # Generate the dockerfile

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -264,6 +264,7 @@ if [ $LXC = "1" ]; then
     echo "sudo will preserve (some) env flags"
     preserve_env=yes # if you would want to set false then unset this variable
   fi
+  [ $APT_CACHER -eq 0 ] && MIRROR=""
   env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBOOTSTRAP_DIR="$DEBOOTSTRAP_DIR" sudo ${preserve_env+--preserve-env} debootstrap --arch=$ARCH --include=$addpkg --exclude=$removepkg --components=$components $SUITE $OUT-bootstrap $MIRROR
   # Fix lxc issue
   if [ -f $OUT-bootstrap/usr/lib/lxc/lxc-init ]
@@ -302,7 +303,8 @@ else
   libexec/config-bootstrap-fixup
 
   rm -rf $OUT
-  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm $DISTRO --rootsize $DISKSIZE --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_rsa.pub --ssh-user-key=var/id_rsa.pub --mirror=$MIRROR --security-mirror=$SECURITY_MIRROR --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup
+  [ $APT_CACHER -eq 1 ] && mirror_options="--mirror=$MIRROR --security-mirror=$SECURITY_MIRROR"
+  env -i LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 sudo vmbuilder kvm $DISTRO --rootsize $DISKSIZE --arch=$ARCH --suite=$SUITE --addpkg=$addpkg --removepkg=$removepkg --ssh-key=var/id_rsa.pub --ssh-user-key=var/id_rsa.pub --dest=$OUT --flavour=$FLAVOUR --firstboot=`pwd`/target-bin/bootstrap-fixup $(echo $mirror_options)
   mv $OUT/*.qcow2 $OUT.qcow2
   rm -rf $OUT
   # bootstrap-fixup is done on first boot

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -221,7 +221,7 @@ WORKDIR /home/$DISTRO
 CMD ["sleep", "infinity"]
 EOF
 
-  docker build --network host --pull -f $OUT.Dockerfile -t $OUT .
+  docker build --pull -f $OUT.Dockerfile -t $OUT .
 
   exit 0
 fi

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -109,7 +109,11 @@ if [ $# != 0 ] ; then
   done
 fi
 
-MIRROR_DEFAULT=127.0.0.1
+if [ $DOCKER = "1" ]; then
+  MIRROR_DEFAULT=172.17.0.1
+else
+  MIRROR_DEFAULT=127.0.0.1
+fi
 MIRROR_BASE=http://${MIRROR_HOST:-$MIRROR_DEFAULT}:3142
 
 if [ $DISTRO = "ubuntu" ]; then

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -9,7 +9,7 @@ LXC=0
 VBOX=0
 DOCKER=0
 DOCKER_IMAGE_HASH=""
-APT_CACHER_DEFAULT=0
+APT_CACHER=1
 
 usage() {
   echo "Usage: ${0##*/} [OPTION]..."
@@ -25,7 +25,7 @@ usage() {
   --vbox                    use VirtualBox instead of kvm
   --docker                  use docker instead of kvm
   --docker-image-hash D     digest of the docker image to build from
-  --enable-apt-cacher       enable APT Cacher
+  --disable-apt-cacher      disable APT Cacher
 
   The MIRROR_HOST environment variable can be used to change the
   apt-cacher host.  It should be something that both the host and the
@@ -90,8 +90,8 @@ if [ $# != 0 ] ; then
         DOCKER=1
         shift 1
         ;;
-      --enable-apt-cacher)
-        APT_CACHER=1
+      --disable-apt-cacher)
+        APT_CACHER=0
         shift 1
         ;;
       --docker-image-digest)
@@ -111,8 +111,6 @@ fi
 
 MIRROR_DEFAULT=127.0.0.1
 MIRROR_BASE=http://${MIRROR_HOST:-$MIRROR_DEFAULT}:3142
-
-APT_CACHER=${APT_CACHER:-$APT_CACHER_DEFAULT}
 
 if [ $DISTRO = "ubuntu" ]; then
   MIRROR=$MIRROR_BASE/archive.ubuntu.com/ubuntu

--- a/libexec/config-bootstrap-fixup
+++ b/libexec/config-bootstrap-fixup
@@ -12,4 +12,8 @@ if [ -z "$MIRROR_HOST" ] || [ "$MIRROR_HOST" == "127.0.0.1" ]; then
   MIRROR_HOST=$GITIAN_HOST_IP
 fi
 
-sed "s;HOSTIP;$MIRROR_HOST;g" < target-bin/bootstrap-fixup.in > target-bin/bootstrap-fixup
+if [ $APT_CACHER = "1" ]; then
+    sed "s;HOSTIP;$MIRROR_HOST;g" < target-bin/bootstrap-fixup.in > target-bin/bootstrap-fixup
+else
+    sed "s;HOSTIP:3142/;;g" < target-bin/bootstrap-fixup.in > target-bin/bootstrap-fixup
+fi

--- a/libexec/make-clean-vm
+++ b/libexec/make-clean-vm
@@ -62,7 +62,6 @@ case $VMSW in
     ;;
   LXC)
     cp -a --sparse=always $BASE $OUT
-    libexec/config-bootstrap-fixup
     on-target -u root bash < target-bin/bootstrap-fixup
     ;;
   VBOX)

--- a/libexec/start-target
+++ b/libexec/start-target
@@ -37,6 +37,6 @@ case $VMSW in
     echo "Gitian-${2}" > var/target.vmname
     ;;
   DOCKER)
-    docker run --network host -d --name gitian-target base-$SUFFIX:latest > /dev/null
+    docker run -d --name gitian-target base-$SUFFIX:latest > /dev/null
     ;;
 esac


### PR DESCRIPTION
Following discuss in https://github.com/devrandom/gitian-builder/pull/249, @devrandom suggested to use apt-cacher by default.

Looks like he's waiting on you do to do changes (see comment https://github.com/devrandom/gitian-builder/issues/227#issuecomment-913679561). Maybe everyone was waiting on each other ! Can be implemented quickly maybe, peoples seem interested in the feature :)

So here some code to implement the change.